### PR TITLE
feat(invite): enhance InviteKeySchema and add expired key cleanup API

### DIFF
--- a/src/modules/admin/resources/access_control.py
+++ b/src/modules/admin/resources/access_control.py
@@ -20,6 +20,7 @@ from src.common.pagination import PageNumberPagination
 
 from openapi import *
 from src.modules.admin.resources import admin_blp
+from src.modules.admin.services import is_invite_key_expired
 
 @admin_blp.route("/invite")
 class InviteUser(MethodView):
@@ -45,6 +46,8 @@ class InviteUser(MethodView):
         invite_key = InviteKeyModel(key=new_key)
         db.session.add(invite_key)
         db.session.commit()
+        
+        invite_key.is_expired = is_invite_key_expired(invite_key)
 
         return invite_key
     
@@ -75,7 +78,13 @@ class InviteUser(MethodView):
         meta = result['meta']
 
         # Serialize items using the schema
-        serialized_items = InviteKeySchema(many=True).dump(items)
+        # serialized_items = InviteKeySchema(many=True).dump(items)
+
+        serialized_items = []
+        for item in items:
+            data = InviteKeySchema().dump(item)
+            data['is_expired'] = is_invite_key_expired(item)
+            serialized_items.append(data)
 
         # Return a JSON response with data and metadata
         return jsonify({
@@ -95,6 +104,20 @@ class InviteKeyRemove(MethodView):
         db.session.delete(invite_key)
         db.session.commit()
         return jsonify({"message": INVITE_KEY_DELETED}), HTTPStatus.OK
+
+@admin_blp.route("/invite/expired")
+class ExpiredInviteKeyRemove(MethodView):
+    """Handles deleting all expired invite keys."""
+    @role_required([ADMIN_ROLE])
+    def delete(self):
+        expired_keys = db.session.query(InviteKeyModel).all()
+        count = 0
+        for key in expired_keys:
+            if is_invite_key_expired(key):
+                db.session.delete(key)
+                count += 1
+        db.session.commit()
+        return jsonify({"message": f"Deleted {count} expired invite keys."}), HTTPStatus.OK
 
 @admin_blp.route("/user")
 class UserList(MethodView):

--- a/src/modules/admin/schemas.py
+++ b/src/modules/admin/schemas.py
@@ -1,5 +1,8 @@
 from marshmallow import Schema, fields
+from src.constants.app_msg import MISSING_FIELD_ERROR
 
 class InviteKeySchema(Schema):
-    key = fields.Str(dump_only=True)
-    created = fields.DateTime(dump_only=True)
+    key = fields.Str(required=True)
+    created = fields.DateTime(required=True)
+    is_expired = fields.Bool(required=True)
+    creator_id = fields.Int(allow_none=True)

--- a/src/modules/auth/schemas.py
+++ b/src/modules/auth/schemas.py
@@ -114,6 +114,12 @@ class UserRegisterSchema(Schema):
         validate_password_match(data)
 
 
+class GroupUserSchema(Schema):
+    name = fields.Str(
+        required=True,
+        error_messages={"required": MISSING_FIELD_ERROR.format("group_name")},
+    )
+
 class UserLoginSchema(Schema):
     id = fields.Int(
         dump_only=True,
@@ -134,6 +140,7 @@ class UserLoginSchema(Schema):
         dump_only=True,
     )
     email = fields.Str(dump_only=True)
+    group = fields.Nested(GroupUserSchema(), dump_only=True)
 
 
 class ChangePasswordSchema(Schema):


### PR DESCRIPTION
- Updated InviteKeySchema to include required fields: key, created, is_expired, creator_id
- Replaced dump_only fields with validation-based schema definition
- Added is_expired evaluation after invite key creation
- Refactored serialization loop to inject is_expired flag per item
- Implemented new endpoint: DELETE /invite/expired to remove expired invite keys